### PR TITLE
removed edge runtime

### DIFF
--- a/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
@@ -2,7 +2,7 @@ import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 
 import { appRouter, createTRPCContext } from "@pogi/api";
 
-export const runtime = "edge";
+// export const runtime = "edge";
 
 /**
  * Configure basic CORS headers


### PR DESCRIPTION
Edge runtime doesn't allow us to use native node modules so that's why the build was failing. our auth is handled in `packages/api` so the entire `api` package will be a traditional nodejs runtime now.